### PR TITLE
Enhancement/BugFix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
   "name": "redux-promise-dispatch",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Simplifying promises with redux and redux-thunk",
   "main": "./dist/module.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kjrocker/redux-promise-dispatch"
+  },
   "scripts": {
     "start": "npm run dev",
     "dev": "npm test -- -w",
     "init": "mkdir dist",
-    "clean": "rm -rf dist",
+    "clean": "rimraf -rf dist",
     "prebuild": "npm run clean && npm run init",
     "build": "babel ./src -d ./dist --ignore test.js",
     "pretest": "npm run build",
     "test": "mocha --compilers js:babel-core/register ./src/**/*.test.js",
     "test:single": "mocha --compilers js:babel-core/register"
   },
-  "keywords": [
-    "redux",
-    "redux-thunk",
-    "promises"
-  ],
+  "keywords": ["redux", "redux-thunk", "promises"],
   "peerDependencies": {
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0"
@@ -32,11 +32,10 @@
     "redux": "^3.7.2",
     "redux-mock-store": "^1.3.0",
     "redux-thunk": "^2.2.0",
+    "rimraf": "^2.6.2",
     "sinon": "^4.1.2"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "author": "Kevin Rocker",
   "license": "MIT"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,14 +8,20 @@ const promiseDispatcher = (fn, { request, success, failure }) => {
 
 // Take a method (from our API service), params, and three named action creators
 // Execute the standard (request -> success | failure) action cycle for that api call
-const promiseDispatchCreator = (fn, { request, success, failure }) => (...params) => {
-  return dispatch => {
+const promiseDispatchCreator = (fn, { request, success, failure }) => (...params) => dispatch =>
+  //adding a return promise so that we can do promise channing
+  new Promise((resolve, reject) => {
     request && dispatch(request(...params));
     return fn(...params)
-      .then(response => dispatch(success(response, ...params)))
-      .catch(error => dispatch(failure(error, ...params)));
-  };
-};
+      .then(response => {
+        dispatch(success(response, ...params));
+        resolve(response);
+      })
+      .catch(error => {
+        dispatch(failure(error, ...params));
+        reject(error);
+      });
+  });
 
 const createActionCreator = name => payload => {
   return {


### PR DESCRIPTION
Added ability for promiseDispatcher to be chainable. 
so your promiseDispatcher can be used to create another promiseDispatcher. This would allow you to re-use actions to create new actions. 
Forced promiseDispatcher to actually need to be caught in the fail condition (previously using then). 